### PR TITLE
Add ability to set interface address

### DIFF
--- a/bin/instance
+++ b/bin/instance
@@ -5,9 +5,10 @@ var db = require('../lib/database');
 var app = require('../app');
 
 app.set('port', process.env.PORT || settings.webserver.port);
+app.set('address', process.env.ADDRESS || settings.webserver.address || '::');
 
 db.connect(null, function() {
-  var server = app.listen(app.get('port'), '::', function() {
+  var server = app.listen(app.get('port'), app.get('address'), function() {
     debug('Express server listening on port ' + server.address().port);
   });
 

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -36,6 +36,8 @@ exports.webserver = {
   // port: Port # to configure the express webserver to listen for http requests on
   //       NOTE: Be sure to configure firewalls to allow traffic through this port or the explorer website may not be accessible remotely
   "port": process.env.PORT || 3001,
+  // address: Interface address to configure the express webserver to listen for http requests on
+  "address": process.env.ADDRESS || "::",
   // tls: a collection of settings that pertain to the TLS (Transport Layer Security) protocol feature (aka: ssl or https)
   "tls": {
     // enabled: Enable/disable TLS

--- a/settings.json.template
+++ b/settings.json.template
@@ -38,6 +38,8 @@
     // port: Port # to configure the express webserver to listen for http requests on
     //       NOTE: Be sure to configure firewalls to allow traffic through this port or the explorer website may not be accessible remotely
     "port": 3001,
+    // address: Interface address to configure the express webserver to listen for http requests on
+    //"address": "0.0.0.0",
     // tls: a collection of settings that pertain to the TLS (Transport Layer Security) protocol feature (aka: ssl or https)
     "tls": {
       // enabled: Enable/disable TLS


### PR DESCRIPTION
This change allows the ability to specify an interface address using `settings.json`.  This is useful in environments where the `::` syntax isn't working and results in an error like `Error: bind EPROTONOSUPPORT`