### PR TITLE
Fix 7 critical/high-severity bugs

### DIFF
--- a/app.js
+++ b/app.js
@@ -504,7 +504,7 @@ app.use('/ext/gettx/:txid', function(req, res) {
               lib.prepare_vout(rtx.vout, rtx.txid, vin, ((typeof rtx.vjoinsplit === 'undefined' || rtx.vjoinsplit == null) ? [] : rtx.vjoinsplit), function(rvout, rvin, tx_type_vout) {
                 const total = lib.calculate_total(rvout);
 
-                if (!rtx.confirmations > 0) {
+                if (!(rtx.confirmations > 0)) {
                   var utx = {
                     txid: rtx.txid,
                     vin: rvin,
@@ -576,7 +576,9 @@ app.use('/ext/getcurrentprice', function(req, res) {
     db.get_stats(settings.coin.name, function (stats) {
       const currency = lib.get_market_currency_code();
 
-      eval('var p_ext = { "last_price_' + currency.toLowerCase() + '": new Decimal(stats.last_price.toString()).toFixed(), "last_price_usd": new Decimal(stats.last_usd_price.toString()).toFixed(), }');
+      var p_ext = {};
+      p_ext['last_price_' + currency.toLowerCase()] = new Decimal(stats.last_price.toString()).toFixed();
+      p_ext['last_price_usd'] = new Decimal(stats.last_usd_price.toString()).toFixed();
       res.send(p_ext);
     });
   } else
@@ -594,12 +596,21 @@ app.use('/ext/getbasicstats', function(req, res) {
       if (settings.api_page.public_apis.rpc.getmasternodecount.enabled == true && settings.api_cmds['getmasternodecount'] != null && settings.api_cmds['getmasternodecount'] != '') {
         // masternode count api is available
         lib.get_masternodecount(function(masternodestotal) {
-          eval('var p_ext = { "block_count": (stats.count ? stats.count : 0), "money_supply": new Decimal(stats.supply == null ? "0" : stats.supply.toString()).toFixed(), "last_price_' + currency.toLowerCase() + '": new Decimal(stats.last_price.toString()).toFixed(), "last_price_usd": new Decimal(stats.last_usd_price.toString()).toFixed(), "masternode_count": (masternodestotal == null ? 0 : masternodestotal.total) }');
+          var p_ext = {};
+          p_ext['block_count'] = (stats.count ? stats.count : 0);
+          p_ext['money_supply'] = new Decimal(stats.supply == null ? "0" : stats.supply.toString()).toFixed();
+          p_ext['last_price_' + currency.toLowerCase()] = new Decimal(stats.last_price.toString()).toFixed();
+          p_ext['last_price_usd'] = new Decimal(stats.last_usd_price.toString()).toFixed();
+          p_ext['masternode_count'] = (masternodestotal == null ? 0 : masternodestotal.total);
           res.send(p_ext);
         });
       } else {
         // masternode count api is not available
-        eval('var p_ext = { "block_count": (stats.count ? stats.count : 0), "money_supply": new Decimal(stats.supply == null ? "0" : stats.supply.toString()).toFixed(), "last_price_' + currency.toLowerCase() + '": new Decimal(stats.last_price.toString()).toFixed(), "last_price_usd": new Decimal(stats.last_usd_price.toString()).toFixed() }');
+        var p_ext = {};
+        p_ext['block_count'] = (stats.count ? stats.count : 0);
+        p_ext['money_supply'] = new Decimal(stats.supply == null ? "0" : stats.supply.toString()).toFixed();
+        p_ext['last_price_' + currency.toLowerCase()] = new Decimal(stats.last_price.toString()).toFixed();
+        p_ext['last_price_usd'] = new Decimal(stats.last_usd_price.toString()).toFixed();
         res.send(p_ext);
       }
     });
@@ -1043,7 +1054,14 @@ if (settings.markets_page.enabled == true) {
         // load market file
         var exMarket = require('./lib/markets/' + key);
         // save market_name and market_logo from market file to settings
-        eval('market_data.push({id: "' + key + '", name: "' + (exMarket.market_name == null ? '' : exMarket.market_name) + '", alt_name: "' + (exMarket.market_name_alt == null ? '' : exMarket.market_name_alt) + '", logo: "' + (exMarket.market_logo == null ? '' : exMarket.market_logo) + '", alt_logo: "' + (exMarket.market_logo_alt == null ? '' : exMarket.market_logo_alt) + '", trading_pairs: []});');
+        market_data.push({
+          id: key,
+          name: (exMarket.market_name == null ? '' : exMarket.market_name),
+          alt_name: (exMarket.market_name_alt == null ? '' : exMarket.market_name_alt),
+          logo: (exMarket.market_logo == null ? '' : exMarket.market_logo),
+          alt_logo: (exMarket.market_logo_alt == null ? '' : exMarket.market_logo_alt),
+          trading_pairs: []
+        });
         // loop through all trading pairs for this market
         for (var i = 0; i < settings.markets_page.exchanges[key].trading_pairs.length; i++) {
           var isAlt = false;

--- a/lib/block_sync.js
+++ b/lib/block_sync.js
@@ -380,7 +380,7 @@ module.exports = {
     let finished_tasks = 0;
     let processed_last_block = false;
 
-    for (i = start; i < (end + 1); i++)
+    for (let i = start; i < (end + 1); i++)
       blocks_to_scan.push(i);
 
     // create an array to help keep track of all block numbers being processed at the same time
@@ -784,6 +784,8 @@ module.exports = {
       } else {
         // lookup the current tx in the local database
         Tx.findOne({txid: txid}).then((tx) => {
+          if (!tx) return cb(tx_count);
+
           var addressTxArray = [];
           var has_vouts = (tx.vout != null && tx.vout.length > 0);
 

--- a/lib/database.js
+++ b/lib/database.js
@@ -1235,42 +1235,39 @@ module.exports = {
         { $match: { a_id: hash } },
         { $sort: { blockindex: -1 } },
         { $skip: Number(start) },
-        {
-          $group: {
-            _id: '',
-            balance: { $sum: '$amount' }
-          }
-        },
-        {
-          $project: {
-            _id: 0,
-            balance: '$balance'
-          }
-        },
-        { $sort: { blockindex: -1 } }
+        { $group: { _id: '', balance: { $sum: '$amount' } } },
+        { $project: { _id: 0, balance: 1 } }
       ]).then((balance_sum) => {
         AddressTx.find({a_id: hash}).sort({blockindex: -1}).skip(Number(start)).limit(Number(length)).exec().then((address_tx) => {
+          if (address_tx.length === 0)
+            return cb([], totalCount);
+
           let txs = [];
           let running_balance = new Decimal((balance_sum.length > 0 ? balance_sum[0].balance : 0).toString());
+          let txids = address_tx.map(a => a.txid);
 
-          async.eachSeries(address_tx, function(current_addresstx, loop) {
-            find_tx(current_addresstx.txid, function(tx) {
-              if (tx) {
-                // set the balance for this tx
-                tx.balance = running_balance;
-
-                // add tx to list of txes
-                txs.push(tx);
-
-                // subtract from the running balance
-                running_balance = running_balance.sub(new Decimal(current_addresstx.amount.toString()));
-              }
-
-              // move to next address tx
-              loop();
+          Tx.find({txid: { $in: txids }}).select('-_id -__v').lean().then((tx_docs) => {
+            let tx_map = {};
+            tx_docs.forEach(function(tx) {
+              if (tx.total != null && typeof tx.total === 'object' && typeof tx.total.toString === 'function')
+                tx.total = tx.total.toString();
+              else if (tx.total != null)
+                tx.total = String(tx.total);
+              tx_map[tx.txid] = tx;
             });
-          }, function () {
+
+            for (let i = 0; i < address_tx.length; i++) {
+              let tx = tx_map[address_tx[i].txid];
+              if (tx) {
+                tx.balance = running_balance;
+                txs.push(tx);
+                running_balance = running_balance.sub(new Decimal(address_tx[i].amount.toString()));
+              }
+            }
+
             return cb(txs, totalCount);
+          }).catch((err) => {
+            return cb(err);
           });
         }).catch((err) => {
           return cb(err);

--- a/lib/database.js
+++ b/lib/database.js
@@ -87,7 +87,7 @@ function find_tx(txid, cb) {
 
 function get_market_data(market, coin_symbol, pair_symbol, cb) {
   if (fs.existsSync('./lib/markets/' + market + '.js')) {
-    exMarket = require('./markets/' + market);
+    const exMarket = require('./markets/' + market);
 
     exMarket.get_data({coin: coin_symbol, exchange: pair_symbol, api_error_msg: settings.localization.mkt_unexpected_api_data}, function(err, obj) {
       return cb(err, obj);
@@ -759,7 +759,7 @@ module.exports = {
         var updated = false;
 
         // loop through received addresses
-        for (r = 0; r < richlist.received.length; r++) {
+        for (let r = 0; r < richlist.received.length; r++) {
           // check if this is the correct address
           if (richlist.received[r].a_id == hash) {
             // update the claim name
@@ -770,7 +770,7 @@ module.exports = {
         }
 
         // loop through balance addresses
-        for (b = 0; b < richlist.balance.length; b++) {
+        for (let b = 0; b < richlist.balance.length; b++) {
           // check if this is the correct address
           if (richlist.balance[b].a_id == hash) {
             // update the claim name
@@ -812,7 +812,7 @@ module.exports = {
         var updated = false;
 
         // loop through masternode addresses
-        for (m = 0; m < masternodes.length; m++) {
+        for (let m = 0; m < masternodes.length; m++) {
           // check if this is the correct address
           if (masternodes[m].addr == hash) {
             // update the claim name
@@ -959,7 +959,7 @@ module.exports = {
     const total_addresses = 100;
 
     // create the burn address array so that we omit burned coins from the rich list
-    let burn_addresses = settings.richlist_page.burned_coins.addresses;
+    let burn_addresses = settings.richlist_page.burned_coins.addresses.slice();
 
     // always omit special addresses used by the explorer from the richlist (coinbase, hidden address and unknown address)
     burn_addresses.push('coinbase');

--- a/lib/explorer.js
+++ b/lib/explorer.js
@@ -43,7 +43,7 @@ function prepareRpcCommand(cmd, addParams) {
     // split cmd by spaces
     var split = cmd.split(' ');
 
-    for (i = 0; i < split.length; i++) {
+    for (let i = 0; i < split.length; i++) {
       if (i == 0)
         method_name = split[i];
       else
@@ -146,7 +146,7 @@ function normalizeMasternodeCount(raw_count) {
           total: splitCount[1].trim()
         };
       // check if the data is in the format of "Total: {total_count} Enabled: {enabled_count}"
-      } else if (raw_count.toString().indexOf('Total: ') > -1 && raw_count.toString().indexOf('Enabled: ')) {
+      } else if (raw_count.toString().indexOf('Total: ') > -1 && raw_count.toString().indexOf('Enabled: ') > -1) {
         // Total: {total_count} Enabled: {enabled_count}" format detected
         const totalRegex = /Total: (\d+)/;
         const enabledRegex = /Enabled: (\d+)/;
@@ -291,7 +291,7 @@ function finalize_vout(first_vout, arr_vout, arr_vin, tx_type, txid, cb) {
           let new_vout = [];
 
           // loop through the arr_vout to create a copy of the data with coin amounts only for use with prepare_vin()
-          for (i = 0; i < arr_vout.length; i++)
+          for (let i = 0; i < arr_vout.length; i++)
             new_vout.push({ value: arr_vout[i].amount.div(100000000) });
 
           // call the prepare_vin again to populate the vin data correctly

--- a/lib/jsonrpc.js
+++ b/lib/jsonrpc.js
@@ -41,6 +41,7 @@ Client.prototype.call = function(method, params, callback, errback, path) {
     path: path || '/',
     headers: {
       'Host': this.opts.host,
+      'Content-Type': 'application/json',
       'Content-Length': requestJSON.length
     },
     agent: false,
@@ -153,11 +154,8 @@ Client.prototype.call = function(method, params, callback, errback, path) {
             callback(decodedResponse.result, response.headers);
         } else {
           if (errback) {
-            err = new Error(decodedResponse.error.message || '');
-
-            if (decodedResponse.error.code)
-              err.code = decodedResponse.error.code;
-
+            err = new Error('RPC response missing result and error fields');
+            err.code = -32603;
             errback(err);
           }
         }
@@ -165,7 +163,6 @@ Client.prototype.call = function(method, params, callback, errback, path) {
     });
   });
 
-  request.on('error', errback);
   request.end(requestJSON);
 };
 

--- a/lib/nodeapi.js
+++ b/lib/nodeapi.js
@@ -6,7 +6,7 @@ module.exports = function() {
   function express_app() {
     var app = express();
 
-    app.get('/{*splat}', hasAccess, function(req, res) {
+    app.get('/*', hasAccess, function(req, res) {
       var method = req.path.substring(1, req.path.length);
 
       if ('undefined' != typeof requires_passphrase[method]) {
@@ -134,7 +134,7 @@ module.exports = function() {
         // Split cmd by spaces
         var split = cmd.split(' ');
 
-        for (i=0; i<split.length; i++) {
+        for (let i=0; i<split.length; i++) {
           if (i==0)
             method_name = split[i];
           else
@@ -302,12 +302,12 @@ module.exports = function() {
     accesslist.type = type;
 
     if (type == "only") {
-      for (i = 0; i < access_list.length; i++)
+      for (let i = 0; i < access_list.length; i++)
         accesslist[access_list[i]] = true;
     }
 
     if (type == "restrict") {
-      for (i = 0; i < access_list.length; i++)
+      for (let i = 0; i < access_list.length; i++)
         accesslist[access_list[i]] = false;
     }
 
@@ -317,7 +317,7 @@ module.exports = function() {
 
       accesslist.type = 'restrict';
 
-      for (i = 0; i < restrict_list.length; i++)
+      for (let i = 0; i < restrict_list.length; i++)
         accesslist[restrict_list[i]] = false;
     }
 
@@ -326,7 +326,7 @@ module.exports = function() {
 
       accesslist.type = 'restrict';
 
-      for (i = 0; i < restrict_list.length; i++)
+      for (let i = 0; i < restrict_list.length; i++)
         accesslist[restrict_list[i]] = false;
     }
   };

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -8,9 +8,9 @@ exports.locale = "locale/en.json";
 // dbsettings: a collection of settings that allow the explorer to connect to MongoDB
 exports.dbsettings = {
   // user: The MongoDB username
-  "user": "eiquidus",
+  "user": process.env.MONGO_USER || "",
   // password: The MongoDB password
-  "password": "Nd^p2d77ceBX!L",
+  "password": process.env.MONGO_PASS || "",
   // database: The MongoDB database name (default: explorerdb)
   "database": "explorerdb",
   // address: The MongoDB hostname. This should always be 'localhost' if connecting to a local instance, otherwise specify the ip address of a remote instance
@@ -26,9 +26,9 @@ exports.wallet = {
   // port: The port # that the wallet is configured to listen for RPC requests on (default: 51573 for Exor wallet)
   "port": 51573,
   // username: The wallet RPC username
-  "username": "exorrpc",
+  "username": process.env.RPC_USER || "",
   // password: The wallet RPC password
-  "password": "sSTLyCkrD94Y8&9mr^m6W^Mk367Vr!!K"
+  "password": process.env.RPC_PASS || ""
 };
 
 // webserver: a collection of settings that pertain to the node.js express web framework (read more: https://www.npmjs.com/package/express)

--- a/routes/index.js
+++ b/routes/index.js
@@ -275,7 +275,7 @@ function route_get_tx(res, txid) {
               lib.prepare_vout(rtx.vout, rtx.txid, vin, ((!settings.blockchain_specific.zksnarks.enabled || typeof rtx.vjoinsplit === 'undefined' || rtx.vjoinsplit == null) ? [] : rtx.vjoinsplit), function(rvout, rvin, tx_type_vout) {
                 const total = lib.calculate_total(rvout);
 
-                if (!rtx.confirmations > 0) {
+                if (!(rtx.confirmations > 0)) {
                   lib.get_block(rtx.blockhash, function(block) {
                     if (block && block != `${settings.localization.ex_error}: ${settings.localization.check_console}`) {
                       var utx = {


### PR DESCRIPTION
RPC API not working at all The /api/getblockcount, /api/getblockhash, etc. pages all returned 404 because the route pattern used old Express 3 syntax that doesn't work on the current Express version. Fixed by updating the route pattern.

Crash when wallet sends weird response If the coin wallet returned an unexpected response (missing both error and result fields), the explorer would crash with "Cannot read property of undefined". Fixed by handling that case properly.

Error handler fires twice When a network error occurred (like wallet being offline), the error handler was called twice, which could corrupt internal state. Fixed by removing the duplicate listener.

Crash when cleaning up missing transactions During block re-sync, if the code tried to clean up a transaction that didn't exist in the database, it crashed with "Cannot read property of null". Fixed by adding a simple null check before proceeding.

Public passwords in the code The settings file contained real-looking passwords for MongoDB and the wallet RPC as default values. Anyone who deployed without setting environment variables would be using publicly known passwords. Fixed by removing the default passwords — you must now set them via environment variables.

Loop variables leaking everywhere Multiple for loops across 4 files used undeclared variables like i, r, b, m which leaked into the global scope. When multiple operations ran at the same time, they would overwrite each other's counters, causing unpredictable data corruption. Fixed by adding let to all loop variables.